### PR TITLE
Update categories of elementary flow 

### DIFF
--- a/EF-Reference-Package/ILCD/flows/7bd57a67-e05a-426a-9b97-16638d41fad9.xml
+++ b/EF-Reference-Package/ILCD/flows/7bd57a67-e05a-426a-9b97-16638d41fad9.xml
@@ -9,8 +9,8 @@
    <classificationInformation>
     <common:elementaryFlowCategorization>
      <common:category level="0">Emissions</common:category>
-     <common:category level="1">Emissions to industrial soil</common:category>
-     <common:category level="2">Other emissions to industrial soil</common:category>
+     <common:category level="1">Emissions to soil</common:category>
+     <common:category level="2">Emissions to non-agricultural soil</common:category>
 </common:elementaryFlowCategorization>
 </classificationInformation>
    <CASNumber>7440-21-3</CASNumber>

--- a/EF-Reference-Package/ILCD/flows/84ae695d-4e87-4e02-9152-261516d4975d.xml
+++ b/EF-Reference-Package/ILCD/flows/84ae695d-4e87-4e02-9152-261516d4975d.xml
@@ -9,8 +9,8 @@
    <classificationInformation>
     <common:elementaryFlowCategorization>
      <common:category level="0">Emissions</common:category>
-     <common:category level="1">Emissions to industrial soil</common:category>
-     <common:category level="2">Other emissions to industrial soil</common:category>
+     <common:category level="1">Emissions to soil</common:category>
+     <common:category level="2">Emissions to non-agricultural soil</common:category>
 </common:elementaryFlowCategorization>
 </classificationInformation>
    <CASNumber>7723-14-0</CASNumber>

--- a/EF-Reference-Package/ILCD/flows/8d467a31-5ee4-4890-83ea-d7d191034dfc.xml
+++ b/EF-Reference-Package/ILCD/flows/8d467a31-5ee4-4890-83ea-d7d191034dfc.xml
@@ -9,8 +9,8 @@
    <classificationInformation>
     <common:elementaryFlowCategorization>
      <common:category level="0">Emissions</common:category>
-     <common:category level="1">Emissions to industrial soil</common:category>
-     <common:category level="2">Other emissions to industrial soil</common:category>
+     <common:category level="1">Emissions to soil</common:category>
+     <common:category level="2">Emissions to non-agricultural soil</common:category>
 </common:elementaryFlowCategorization>
 </classificationInformation>
    <common:generalComment xml:lang="en">Reference elementary flow of the International Reference Life Cycle Data System (ILCD).</common:generalComment>

--- a/EF-Reference-Package/ILCD/flows/bc2fed3b-e802-46c1-8609-8798154bb9bd.xml
+++ b/EF-Reference-Package/ILCD/flows/bc2fed3b-e802-46c1-8609-8798154bb9bd.xml
@@ -9,8 +9,8 @@
    <classificationInformation>
     <common:elementaryFlowCategorization>
      <common:category level="0">Emissions</common:category>
-     <common:category level="1">Emissions to industrial soil</common:category>
-     <common:category level="2">Other emissions to industrial soil</common:category>
+     <common:category level="1">Emissions to soil</common:category>
+     <common:category level="2">Emissions to non-agricultural soil</common:category>
 </common:elementaryFlowCategorization>
 </classificationInformation>
    <CASNumber>7440-44-0</CASNumber>


### PR DESCRIPTION
@linancn 
This PR updates the emissions categorization in the elementary flows of carbon, phosphorus, silicon, and oil. Specifically, it modifies the XML files for these flows to change the category from "Emissions to industrial soil" and "Other emissions to industrial soil" to "Emissions to soil" and "Emissions to non-agricultural soil." This adjustment ensures a more accurate classification of emissions destinations in the dataset.

Summary of changes:
Updated category level 1 from "Emissions to industrial soil" to "Emissions to soil"
Updated category level 2 from "Other emissions to industrial soil" to "Emissions to non-agricultural soil"
Applied these changes in four flow XML files related to carbon, phosphorus, silicon, and oil elementary flows
These updates improve the consistency and accuracy of emissions categorization in the ILCD flows.