### PR TITLE
Align energy flow property descriptions and add changelog tooling

### DIFF
--- a/EF-Reference-Package/ILCD/flows/04202046-6556-11dd-ad8b-0800200c9a66.xml
+++ b/EF-Reference-Package/ILCD/flows/04202046-6556-11dd-ad8b-0800200c9a66.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/04202047-6556-11dd-ad8b-0800200c9a66.xml
+++ b/EF-Reference-Package/ILCD/flows/04202047-6556-11dd-ad8b-0800200c9a66.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/04202048-6556-11dd-ad8b-0800200c9a66.xml
+++ b/EF-Reference-Package/ILCD/flows/04202048-6556-11dd-ad8b-0800200c9a66.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/04202049-6556-11dd-ad8b-0800200c9a66.xml
+++ b/EF-Reference-Package/ILCD/flows/04202049-6556-11dd-ad8b-0800200c9a66.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/0420204a-6556-11dd-ad8b-0800200c9a66.xml
+++ b/EF-Reference-Package/ILCD/flows/0420204a-6556-11dd-ad8b-0800200c9a66.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-9136-0050c2490048.xml
+++ b/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-9136-0050c2490048.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-9137-0050c2490048.xml
+++ b/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-9137-0050c2490048.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-9138-0050c2490048.xml
+++ b/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-9138-0050c2490048.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-9139-0050c2490048.xml
+++ b/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-9139-0050c2490048.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-913a-0050c2490048.xml
+++ b/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-913a-0050c2490048.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-913b-0050c2490048.xml
+++ b/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-913b-0050c2490048.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-913c-0050c2490048.xml
+++ b/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-913c-0050c2490048.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-913d-0050c2490048.xml
+++ b/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-913d-0050c2490048.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-91b3-0050c2490048.xml
+++ b/EF-Reference-Package/ILCD/flows/08a91e70-3ddc-11dd-91b3-0050c2490048.xml
@@ -49,7 +49,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/309b272a-6773-4abe-9a8a-6fb539944d1b.xml
+++ b/EF-Reference-Package/ILCD/flows/309b272a-6773-4abe-9a8a-6fb539944d1b.xml
@@ -48,7 +48,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/3e4d2966-6556-11dd-ad8b-0800200c9a66.xml
+++ b/EF-Reference-Package/ILCD/flows/3e4d2966-6556-11dd-ad8b-0800200c9a66.xml
@@ -49,7 +49,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/3e4d9eab-6556-11dd-ad8b-0800200c9a66.xml
+++ b/EF-Reference-Package/ILCD/flows/3e4d9eab-6556-11dd-ad8b-0800200c9a66.xml
@@ -52,7 +52,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/659e3dbc-a46b-47b4-8539-e41a6068d6a8.xml
+++ b/EF-Reference-Package/ILCD/flows/659e3dbc-a46b-47b4-8539-e41a6068d6a8.xml
@@ -48,7 +48,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/d86b9e85-6555-11dd-ad8b-0800200c9a66.xml
+++ b/EF-Reference-Package/ILCD/flows/d86b9e85-6555-11dd-ad8b-0800200c9a66.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/d86bec83-6555-11dd-ad8b-0800200c9a66.xml
+++ b/EF-Reference-Package/ILCD/flows/d86bec83-6555-11dd-ad8b-0800200c9a66.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/d86beca9-6555-11dd-ad8b-0800200c9a66.xml
+++ b/EF-Reference-Package/ILCD/flows/d86beca9-6555-11dd-ad8b-0800200c9a66.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/d86c3aa4-6555-11dd-ad8b-0800200c9a66.xml
+++ b/EF-Reference-Package/ILCD/flows/d86c3aa4-6555-11dd-ad8b-0800200c9a66.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/e2fba107-6555-11dd-ad8b-0800200c9a66.xml
+++ b/EF-Reference-Package/ILCD/flows/e2fba107-6555-11dd-ad8b-0800200c9a66.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/fe0acd60-3ddc-11dd-a6f8-0050c2490048.xml
+++ b/EF-Reference-Package/ILCD/flows/fe0acd60-3ddc-11dd-a6f8-0050c2490048.xml
@@ -52,7 +52,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/fe0acd60-3ddc-11dd-a6f9-0050c2490048.xml
+++ b/EF-Reference-Package/ILCD/flows/fe0acd60-3ddc-11dd-a6f9-0050c2490048.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/fe0acd60-3ddc-11dd-a6fa-0050c2490048.xml
+++ b/EF-Reference-Package/ILCD/flows/fe0acd60-3ddc-11dd-a6fa-0050c2490048.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/fe0acd60-3ddc-11dd-a6fc-0050c2490048.xml
+++ b/EF-Reference-Package/ILCD/flows/fe0acd60-3ddc-11dd-a6fc-0050c2490048.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/flows/fe0acd60-3ddc-11dd-a6fd-0050c2490048.xml
+++ b/EF-Reference-Package/ILCD/flows/fe0acd60-3ddc-11dd-a6fd-0050c2490048.xml
@@ -47,7 +47,7 @@
   <flowProperties>
     <flowProperty dataSetInternalID="0">
       <referenceToFlowPropertyDataSet refObjectId="93a60a56-a3c8-11da-a746-0800200c9a66" type="flow property data set" uri="../flowproperties/93a60a56-a3c8-11da-a746-0800200c9a66.xml">
-        <common:shortDescription xml:lang="en">Radioactivity</common:shortDescription>
+        <common:shortDescription xml:lang="en">Net calorific value</common:shortDescription>
 </referenceToFlowPropertyDataSet>
       <meanValue>1.0</meanValue>
 </flowProperty>

--- a/EF-Reference-Package/ILCD/lciamethods/b2ad6110-c78d-11e6-9d9d-cec0c932ce01.xml
+++ b/EF-Reference-Package/ILCD/lciamethods/b2ad6110-c78d-11e6-9d9d-cec0c932ce01.xml
@@ -79,7 +79,7 @@
 </administrativeInformation>
  <characterisationFactors>
   <factor>
-<referenceToFlowDataSet refObjectId="fe0acd60-3ddc-11dd-a6f9-0050c2490048" type="flow data set" uri="../flows/fe0acd60-3ddc-11dd-a6f9-0050c2490048.xml" version="04.00.004"> <common:shortDescription xml:lang="en">brown coal(Radioactivity,MJ,Non-renewable energy resources from ground)</common:shortDescription>
+<referenceToFlowDataSet refObjectId="fe0acd60-3ddc-11dd-a6f9-0050c2490048" type="flow data set" uri="../flows/fe0acd60-3ddc-11dd-a6f9-0050c2490048.xml" version="04.00.004"> <common:shortDescription xml:lang="en">brown coal(Net calorific value,MJ,Non-renewable energy resources from ground)</common:shortDescription>
 </referenceToFlowDataSet>
 <exchangeDirection>Input</exchangeDirection>
 <meanValue>1.00E+00</meanValue>
@@ -87,7 +87,7 @@
   <generalComment/>
 </factor>
   <factor>
-<referenceToFlowDataSet refObjectId="fe0acd60-3ddc-11dd-a6f8-0050c2490048" type="flow data set" uri="../flows/fe0acd60-3ddc-11dd-a6f8-0050c2490048.xml" version="04.00.004"> <common:shortDescription xml:lang="en">crude oil(Radioactivity,MJ,Non-renewable energy resources from ground)</common:shortDescription>
+<referenceToFlowDataSet refObjectId="fe0acd60-3ddc-11dd-a6f8-0050c2490048" type="flow data set" uri="../flows/fe0acd60-3ddc-11dd-a6f8-0050c2490048.xml" version="04.00.004"> <common:shortDescription xml:lang="en">crude oil(Net calorific value,MJ,Non-renewable energy resources from ground)</common:shortDescription>
 </referenceToFlowDataSet>
 <exchangeDirection>Input</exchangeDirection>
 <meanValue>1.00E+00</meanValue>
@@ -95,7 +95,7 @@
   <generalComment/>
 </factor>
   <factor>
-<referenceToFlowDataSet refObjectId="fe0acd60-3ddc-11dd-a6fc-0050c2490048" type="flow data set" uri="../flows/fe0acd60-3ddc-11dd-a6fc-0050c2490048.xml" version="04.00.004"> <common:shortDescription xml:lang="en">hard coal(Radioactivity,MJ,Non-renewable energy resources from ground)</common:shortDescription>
+<referenceToFlowDataSet refObjectId="fe0acd60-3ddc-11dd-a6fc-0050c2490048" type="flow data set" uri="../flows/fe0acd60-3ddc-11dd-a6fc-0050c2490048.xml" version="04.00.004"> <common:shortDescription xml:lang="en">hard coal(Net calorific value,MJ,Non-renewable energy resources from ground)</common:shortDescription>
 </referenceToFlowDataSet>
 <exchangeDirection>Input</exchangeDirection>
 <meanValue>1.00E+00</meanValue>
@@ -103,7 +103,7 @@
   <generalComment/>
 </factor>
   <factor>
-<referenceToFlowDataSet refObjectId="fe0acd60-3ddc-11dd-a6fa-0050c2490048" type="flow data set" uri="../flows/fe0acd60-3ddc-11dd-a6fa-0050c2490048.xml" version="04.00.004"> <common:shortDescription xml:lang="en">natural gas(Radioactivity,MJ,Non-renewable energy resources from ground)</common:shortDescription>
+<referenceToFlowDataSet refObjectId="fe0acd60-3ddc-11dd-a6fa-0050c2490048" type="flow data set" uri="../flows/fe0acd60-3ddc-11dd-a6fa-0050c2490048.xml" version="04.00.004"> <common:shortDescription xml:lang="en">natural gas(Net calorific value,MJ,Non-renewable energy resources from ground)</common:shortDescription>
 </referenceToFlowDataSet>
 <exchangeDirection>Input</exchangeDirection>
 <meanValue>1.00E+00</meanValue>
@@ -111,7 +111,7 @@
   <generalComment/>
 </factor>
   <factor>
-<referenceToFlowDataSet refObjectId="e2fba107-6555-11dd-ad8b-0800200c9a66" type="flow data set" uri="../flows/e2fba107-6555-11dd-ad8b-0800200c9a66.xml" version="04.00.004"> <common:shortDescription xml:lang="en">peat(Radioactivity,MJ,Non-renewable energy resources from ground)</common:shortDescription>
+<referenceToFlowDataSet refObjectId="e2fba107-6555-11dd-ad8b-0800200c9a66" type="flow data set" uri="../flows/e2fba107-6555-11dd-ad8b-0800200c9a66.xml" version="04.00.004"> <common:shortDescription xml:lang="en">peat(Net calorific value,MJ,Non-renewable energy resources from ground)</common:shortDescription>
 </referenceToFlowDataSet>
 <exchangeDirection>Input</exchangeDirection>
 <meanValue>1.00E+00</meanValue>
@@ -119,7 +119,7 @@
   <generalComment/>
 </factor>
   <factor>
-<referenceToFlowDataSet refObjectId="3e4d2966-6556-11dd-ad8b-0800200c9a66" type="flow data set" uri="../flows/3e4d2966-6556-11dd-ad8b-0800200c9a66.xml" version="03.00.004"> <common:shortDescription xml:lang="en">uranium(Radioactivity,MJ,Non-renewable energy resources from ground)</common:shortDescription>
+<referenceToFlowDataSet refObjectId="3e4d2966-6556-11dd-ad8b-0800200c9a66" type="flow data set" uri="../flows/3e4d2966-6556-11dd-ad8b-0800200c9a66.xml" version="03.00.004"> <common:shortDescription xml:lang="en">uranium(Net calorific value,MJ,Non-renewable energy resources from ground)</common:shortDescription>
 </referenceToFlowDataSet>
 <exchangeDirection>Input</exchangeDirection>
 <meanValue>1.00E+00</meanValue>

--- a/change-log/EF-changelog-writing-worflow.prompt.md
+++ b/change-log/EF-changelog-writing-worflow.prompt.md
@@ -1,0 +1,10 @@
+# Change Log Workflow
+
+1. Make your changes inside `EF-Reference-Package` and commit them as usual.
+2. Run `change-log/update_changelog.sh <commit>` (defaults to `HEAD`). The script:
+   - Ensures the commit touches `EF-Reference-Package`.
+   - Extracts the date, subject, first paragraph of the message body, and the touched files.
+   - Appends a new entry to `change-log/change-log.md` unless that commit hash already exists.
+3. Review and commit the updated changelog alongside your other changes.
+
+The script can be wired into your CLI workflow (for example as a `post-commit` hook) by invoking it automatically after each successful commit.

--- a/change-log/change-log.md
+++ b/change-log/change-log.md
@@ -1,0 +1,19 @@
+# EF Reference Package Change Log
+
+_All entries reflect commits that touch the `EF-Reference-Package` directory._
+
+## 2025-11-13
+- Standardised the `shortDescription` for 28 energy-related flow XMLs from "Radioactivity" to "Net calorific value" to match the property that is actually expressed.
+- Updated `EF-Reference-Package/ILCD/lciamethods/b2ad6110-c78d-11e6-9d9d-cec0c932ce01.xml` so the impact method metadata stays aligned with the renamed flow property.
+
+## 2025-09-19
+- Normalised four LCIA method names (files `01500b74…`, `9ec743ea…`, `dacd48b5…`, `fd530f00…`) to follow the current naming convention, preventing duplicate or ambiguous labels in downstream tooling.
+
+## 2025-09-02
+- Added the missing Chinese translation string for 25 LCIA method definitions so bilingual UIs can render the "impact category" label consistently.
+
+## 2025-06-06
+- Reassigned the emissions category metadata for four elementary flows (carbon, phosphorus, silicon and oil) so they map to the correct impact pathway in EF calculations.
+
+## 2024-09-29
+- Initial import of the EF Reference Package datasets, including the complete ILCD flows, flow properties, categories, documents and supporting references.

--- a/change-log/update_changelog.sh
+++ b/change-log/update_changelog.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_DIR="EF-Reference-Package"
+LOG_FILE="change-log/change-log.md"
+COMMIT_REF="${1:-HEAD}"
+
+if [ ! -f "$LOG_FILE" ]; then
+  cat <<'HDR' > "$LOG_FILE"
+# EF Reference Package Change Log
+
+_All entries reflect commits that touch the `EF-Reference-Package` directory._
+HDR
+fi
+
+if ! git rev-parse --verify "$COMMIT_REF" >/dev/null 2>&1; then
+  echo "Commit $COMMIT_REF not found" >&2
+  exit 1
+fi
+
+changed_files=$(git diff-tree --no-commit-id --name-only -r "$COMMIT_REF" -- "$TARGET_DIR" || true)
+if [ -z "$changed_files" ]; then
+  echo "Commit $COMMIT_REF does not touch $TARGET_DIR; nothing to do." >&2
+  exit 0
+fi
+
+short_hash=$(git rev-parse --short "$COMMIT_REF")
+commit_date=$(git show -s --format=%cs "$COMMIT_REF")
+subject=$(git show -s --format=%s "$COMMIT_REF")
+body=$(git show -s --format=%b "$COMMIT_REF" | sed '/^$/q')
+file_list=$(printf '%s\n' "$changed_files" | sed "s#^$TARGET_DIR/##" | paste -sd ', ' -)
+
+if grep -q "$short_hash" "$LOG_FILE"; then
+  echo "Entry for $short_hash already exists in $LOG_FILE; skipping." >&2
+  exit 0
+fi
+
+echo >> "$LOG_FILE"
+printf '## %s\n' "$commit_date" >> "$LOG_FILE"
+printf -- '- %s\n' "$subject" >> "$LOG_FILE"
+if [ -n "$body" ]; then
+  printf -- '- %s\n' "$body" >> "$LOG_FILE"
+fi
+printf -- '- Files: %s\n' "$file_list" >> "$LOG_FILE"
+
+echo "Changelog updated for commit $short_hash"


### PR DESCRIPTION
@linancn 

## Summary
- add a reusable changelog workflow + helper script and seed the change log
- rename the affected flow-property descriptions from “Radioactivity” to “Net calorific value” across the energy resource flows
- propagate the same naming fix into the LCIA method factors so metadata stays consistent